### PR TITLE
Fix HTTP Ping for domains containing http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-== Description
-  A collection of classes that provide different ways to ping computers.
+* net-ping
+A collection of classes that provide different ways to ping computers.
 
-== Prerequisites
+** Prerequisites
   * ffi
   * win32-security (MS Windows only)
   * fakeweb (test only)
@@ -10,33 +10,30 @@
   Ruby users should use Ruby 1.9.3 or later.
   JRuby users should use JRuby 1.6.7 or later.
 
-== Installation
-  gem install net-ping
+** Installation
+  `gem install net-ping`
 
-== Maintainer Wanted!
-  I would very much like to turn this gem over to someone who is using it
-  more actively than I am. Please let me know if you are interested!
-
-== Notes
+** Notes
   Please read the documentation under the 'doc' directory. Especially pay
   attention to the documentation pertaining to ECONNREFUSED and TCP pings.
 
   Also note the documentation regarding down hosts.
-== How to require net-ping
+
+** How to require net-ping
   You can do either this:
 
-  require 'net/ping'
+  `require 'net/ping'`
 
   In which case you will get Net::Ping and all of its subclasses. Or,
   you can load individual subclasses like this:
 
-  require 'net/ping/tcp'
+  `require 'net/ping/tcp'`
 
   The former has the advantage of being easier to remember and all inclusive,
   not to mention backwards compatible. The latter has the advantage of
   reducing your memory footprint.
-   
-== Known Issues
+
+** Known Issues
   Older versions of Ruby 1.9.x may not work with UDP pings.
 
   Older versions of JRuby will return false positives in UDP pings
@@ -48,19 +45,19 @@
   ICMP pings will not work with JRuby without some sort of third-party
   library support for raw sockets in Java, such as RockSaw.
 
-== License
+** License
   Artistic 2.0
 
-== Contributions
+** Contributions
   Although this library is free, please consider having your company
   setup a gittip if used by your company professionally.
 
   http://www.gittip.com/djberg96/
-   
-== More documentation
+
+** More documentation
   If you installed this library via Rubygems, you can view the inline
   documentation via ri or fire up 'gem server', and point your browser at
   http://localhost:8808.
 
-== Author
+** Author
   Daniel J. Berger

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-* net-ping
+# net-ping
 A collection of classes that provide different ways to ping computers.
 
-** Prerequisites
+## Prerequisites
   * ffi
   * win32-security (MS Windows only)
   * fakeweb (test only)
@@ -10,30 +10,30 @@ A collection of classes that provide different ways to ping computers.
   Ruby users should use Ruby 1.9.3 or later.
   JRuby users should use JRuby 1.6.7 or later.
 
-** Installation
-  `gem install net-ping`
+## Installation
+  ```gem install net-ping```
 
-** Notes
+## Notes
   Please read the documentation under the 'doc' directory. Especially pay
   attention to the documentation pertaining to ECONNREFUSED and TCP pings.
 
   Also note the documentation regarding down hosts.
 
-** How to require net-ping
+## How to require net-ping
   You can do either this:
 
-  `require 'net/ping'`
+  ```require 'net/ping'```
 
   In which case you will get Net::Ping and all of its subclasses. Or,
   you can load individual subclasses like this:
 
-  `require 'net/ping/tcp'`
+  ```require 'net/ping/tcp'```
 
   The former has the advantage of being easier to remember and all inclusive,
   not to mention backwards compatible. The latter has the advantage of
   reducing your memory footprint.
 
-** Known Issues
+## Known Issues
   Older versions of Ruby 1.9.x may not work with UDP pings.
 
   Older versions of JRuby will return false positives in UDP pings
@@ -45,19 +45,19 @@ A collection of classes that provide different ways to ping computers.
   ICMP pings will not work with JRuby without some sort of third-party
   library support for raw sockets in Java, such as RockSaw.
 
-** License
+## License
   Artistic 2.0
 
-** Contributions
+## Contributions
   Although this library is free, please consider having your company
   setup a gittip if used by your company professionally.
 
   http://www.gittip.com/djberg96/
 
-** More documentation
+## More documentation
   If you installed this library via Rubygems, you can view the inline
   documentation via ri or fire up 'gem server', and point your browser at
   http://localhost:8808.
 
-** Author
+## Author
   Daniel J. Berger

--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -79,7 +79,7 @@ module Net
       bool = false
 
       # See https://bugs.ruby-lang.org/issues/8645
-      host = "http://#{host}" unless host.include?("http")
+      host = "http://#{host}" unless /\A(http(s)?:\/\/)/.match(host)
 
       uri = URI.parse(host)
 

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -23,6 +23,12 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     FakeWeb.register_uri(:head, @uri, :body => "PONG")
     FakeWeb.register_uri(:head, @uri_https, :body => "PONG")
     FakeWeb.register_uri(:get, @uri_https, :body => "PONG")
+    FakeWeb.register_uri(:get, "http://#{@uri_http_domain}", :body => "PONG")
+    FakeWeb.register_uri(:head, "http://#{@uri_http_domain}", :body => "PONG")
+    FakeWeb.register_uri(:get, @uri_http_domain_scheme, :body => "PONG")
+    FakeWeb.register_uri(:head, @uri_http_domain_scheme, :body => "PONG")
+    FakeWeb.register_uri(:get, @uri_http_domain_schemes, :body => "PONG")
+    FakeWeb.register_uri(:head, @uri_http_domain_schemes, :body => "PONG")
     FakeWeb.register_uri(:head, "http://jigsaw.w3.org/HTTP/300/302.html",
                          :body => "PONG",
                          :location => "#{@uri}",

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -13,6 +13,9 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     ENV['http_proxy'] = ENV['https_proxy'] = ENV['no_proxy'] = nil
     @uri = 'http://www.google.com/index.html'
     @uri_https = 'https://encrypted.google.com'
+    @uri_http_domain = 'http.com'
+    @uri_http_domain_scheme = 'http://http.com'
+    @uri_http_domain_schemes = 'https://http.com'
     @proxy = 'http://username:password@proxymoxie:3128'
     FakeWeb.allow_net_connect = false
 
@@ -31,12 +34,30 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
                          :status => ["502", "Bad Gateway"])
 
     @http = Net::Ping::HTTP.new(@uri, 80, 30)
+    @http_http_domain = Net::Ping::HTTP.new(@uri_http_domain, 80, 30)
+    @http_http_domain_scheme = Net::Ping::HTTP.new(@uri_http_domain_scheme, 80, 30)
+    @http_http_domain_schemes = Net::Ping::HTTP.new(@uri_http_domain_schemes, 80, 30)
     @bad  = Net::Ping::HTTP.new('http://www.blabfoobarurghxxxx.com') # One hopes not
   end
 
   test 'ping basic functionality' do
     assert_respond_to(@http, :ping)
     assert_nothing_raised{ @http.ping }
+  end
+
+  test 'ping site with http in domain' do
+    assert_respond_to(@http_http_domain, :ping)
+    assert_nothing_raised{ @http_http_domain.ping }
+  end
+
+  test 'ping site with http in domain and http scheme' do
+    assert_respond_to(@http_http_domain_scheme, :ping)
+    assert_nothing_raised{ @http_http_domain_scheme.ping }
+  end
+
+  test 'ping site with http in domain and https scheme' do
+    assert_respond_to(@http_http_domain_schemes, :ping)
+    assert_nothing_raised{ @http_http_domain_schemes.ping }
   end
 
   test 'ping returns a boolean value' do


### PR DESCRIPTION
Discovered by @Criten

Currently Net::Ping::HTTP.ping checks anywhere inside the url string for `http`.

This can be problematic for domains names that contain `http`, e.g. `http.com`.

If a domain with http in it is submitted to Net::Ping::HTTP without a scheme it will fail.

E.G.

```
  url = Net::Ping::HTTP.new("http.com", 80, 30)
  url.ping   <= false
```

and

```
  url = Net::Ping::HTTP.new("http://http.com", 80, 30)
  url.ping   <= true
```

This PR will fix that issue, relevant unit tests have been included.

--Mike
