### PR TITLE
Minor refactoring of the ping?/pingecho aliases, and fixed a timer glitch in Net::Ping::TCP

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -131,8 +131,6 @@ module Net
       bool
     end
 
-    alias ping? ping
-    alias pingecho ping
     alias follow_redirect? follow_redirect
     alias uri host
     alias uri= host=

--- a/lib/net/ping/icmp.rb
+++ b/lib/net/ping/icmp.rb
@@ -147,12 +147,7 @@ module Net
 
       # There is no duration if the ping failed
       @duration = Time.now - start_time if bool
-
-      return bool
     end
-
-    alias ping? ping
-    alias pingecho ping
 
     private
 

--- a/lib/net/ping/ping.rb
+++ b/lib/net/ping/ping.rb
@@ -89,8 +89,12 @@ module Net
          @warning   = nil
          @duration  = nil
       end
-
-      alias ping? ping
+ 
+      def ping?(host = @host)
+        !!ping(host)
+      end
+       
       alias pingecho ping
+
    end
 end

--- a/lib/net/ping/tcp.rb
+++ b/lib/net/ping/tcp.rb
@@ -38,7 +38,6 @@ module Net
       super(host)
 
       bool = false
-      start_time = Time.now
 
       # Failure here most likely means bad host, so just bail.
       begin
@@ -54,6 +53,8 @@ module Net
 
         # This may not be entirely necessary
         sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+
+        start_time = Time.now
 
         begin
           # Where addr[0][3] is an IP address
@@ -95,13 +96,9 @@ module Net
 
       # There is no duration if the ping failed
       @duration = Time.now - start_time if bool
-
-      bool
     end
 
-    alias ping? ping
-    alias pingecho ping
-
+  
     # Class method aliases. DEPRECATED.
     class << self
       alias econnrefused service_check

--- a/lib/net/ping/udp.rb
+++ b/lib/net/ping/udp.rb
@@ -113,7 +113,5 @@ module Net
       bool
     end
 
-    alias ping? ping
-    alias pingecho ping
   end
 end

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -71,12 +71,12 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     assert_boolean(@bad.ping?)
   end
 
-  test 'ping? is an alias for ping' do
-    assert_alias_method(@http, :ping?, :ping)
+  test "ping? is inherited" do
+    assert_respond_to(@http, :ping?)
   end
 
-  test 'pingecho is an alias for ping' do
-    assert_alias_method(@http, :pingecho, :ping)
+  test "pingecho is inherited" do
+    assert_respond_to(@http, :pingecho)
   end
 
   test 'ping should succeed for a valid website' do

--- a/test/test_net_ping_icmp.rb
+++ b/test/test_net_ping_icmp.rb
@@ -43,16 +43,16 @@ class TC_PingICMP < Test::Unit::TestCase
     assert_nothing_raised{ @icmp.ping(@host) }
   end
 
-  test "icmp ping returns a boolean" do
+  test "icmp ping returns a float" do
     omit_if(@@jruby)
-    assert_boolean(@icmp.ping)
-    assert_boolean(@icmp.ping(@host))
+    assert_kind_of(Float, @icmp.ping)
+    assert_kind_of(Float, @icmp.ping(@host))
   end
 
   test "icmp ping of local host is successful" do
     omit_if(@@jruby)
     assert_true(Net::Ping::ICMP.new(@host).ping?)
-    assert_true(Net::Ping::ICMP.new('192.168.0.1').ping?)
+    assert_true(Net::Ping::ICMP.new('127.0.0.1').ping?)
   end
 
   test "threaded icmp ping returns expected results" do
@@ -78,14 +78,12 @@ class TC_PingICMP < Test::Unit::TestCase
     threads.each{ |t| t.join }
   end
 
-  test "ping? is an alias for ping" do
+  test "ping? is inherited" do
     assert_respond_to(@icmp, :ping?)
-    assert_alias_method(@icmp, :ping?, :ping)
   end
 
-  test "pingecho is an alias for ping" do
+  test "pingecho is inherited" do
     assert_respond_to(@icmp, :pingecho)
-    assert_alias_method(@icmp, :pingecho, :ping)
   end
 
   test "icmp ping fails if host is invalid" do
@@ -171,7 +169,7 @@ class TC_PingICMP < Test::Unit::TestCase
   test "setting an odd data_size is valid" do
     omit_if(@@jruby)
     assert_nothing_raised{ @icmp.data_size = 57 }
-    assert_boolean(@icmp.ping)
+    assert_kind_of(Float, @icmp.ping)
   end
 
   def teardown

--- a/test/test_net_ping_udp.rb
+++ b/test/test_net_ping_udp.rb
@@ -26,14 +26,12 @@ class TC_Net_Ping_UDP < Test::Unit::TestCase
     assert_nothing_raised{ @udp.ping(@host) }
   end
 
-  test "ping? is an alias for ping" do
+  test "ping? is inherited" do
     assert_respond_to(@udp, :ping?)
-    assert_alias_method(@udp, :ping?, :ping)
   end
 
-  test "pingecho is an alias for ping" do
+  test "pingecho is inherited" do
     assert_respond_to(@udp, :pingecho)
-    assert_alias_method(@udp, :pingecho, :ping)
   end
 
   test "a successful udp ping returns true" do


### PR DESCRIPTION
- Moved the "ping?" and "pingecho" aliases to the `Ping` superclass
- Change of behaviour: "ping?" returns a boolean, and "ping" returns a float (the ping time)
- Moved the ping timer start in `Net::Ping::TCP` to be after the DNS lookup
