### PR TITLE
Ability to run ICMP pings as non-root if process has set_cap net_raw

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -3,7 +3,7 @@ require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name      = 'net-ping'
-  spec.version   = '2.0.0'
+  spec.version   = '2.0.1'
   spec.license   = 'Artistic 2.0'
   spec.author    = 'Chris Chernesky'
   spec.email     = 'chris.netping@tinderglow.com'

--- a/test/test_net_ping.rb
+++ b/test/test_net_ping.rb
@@ -17,8 +17,19 @@ if File::ALT_SEPARATOR
     require 'test_net_ping_icmp'
   end
 else
-  if Process.euid == 0
-    require 'test_net_ping_icmp'
+  # If cap2 is availble, check if we are root, or our process has net_raw,
+  # then include ICMP tests
+  begin
+    require 'cap2'
+    current_process = Cap2.process
+    if Process.euid == 0 \
+      || current_process.permitted?(:net_raw) \
+      && current_process.enabled?(:net_raw)
+      require 'test_net_ping_icmp'
+    end
+  rescue LoadError
+    # If we don't have cap2, include ICMP tests if we are root
+    require 'test_net_ping_icmp' if Process.euid == 0
   end
 end
 


### PR DESCRIPTION
resolves #15 

Cap2 is used by the ICMP ping code to get the current process capabilities. If the code doesn’t detect cap2, ICMP works like it used to (requiring root). Reasoning for that is so the gem doesn’t’ have to require cap2, but instead takes advantage of it if it finds it is available.