### PR TITLE
Redirection: Port handling and start time reset

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -106,7 +106,10 @@ module Net
               break
             end
             redirect = URI.parse(response['location'])
+            port = redirect.port
             redirect = uri + redirect if redirect.relative?
+
+            start_time = Time.now
             response = do_ping(redirect, port)
             rlimit += 1
           end


### PR DESCRIPTION
If you get redirected from an http:// site to a https:// location, the port 80 still persists, which results a redirect loop or a protocol error (see [here](https://github.com/djberg96/net-ping/blob/master/lib/net/ping/http.rb#L110)). For example try it with:
```ruby
require 'net/ping'
http = Net::Ping::HTTP.new 'http://ebay.de'
http.ping
p http
# => #<Net::Ping::HTTP:0x00559062e49c68 @follow_redirect=true, @redirect_limit=5, @ssl_verify_mode=0, @get_request=false, @code="301", @port=80, @host="http://ebay.de", @timeout=5, @exception="Net::OpenTimeout", @warning=nil, @duration=nil, @proxied=false>
```
By the way I refreshed the `start_time` to get the duration for the redirected query, not the redirection itself (from the beginning). Maybe there could be a separate `total_duration` variable indicating the total duration for the whole redirection. Please decide :)