### PR TITLE
Fixed Ping::HTTP to support custom User-Agent

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -162,9 +162,9 @@ module Net
         @proxied = http.proxy?
 
         if @get_request == true
-          request = Net::HTTP::Get.new(uri_path)
+          request = Net::HTTP::Get.new(uri_path, headers)
         else
-          request = Net::HTTP::Head.new(uri_path)
+          request = Net::HTTP::Head.new(uri_path, headers)
         end
 
         if uri.scheme == 'https'

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -179,6 +179,7 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
   test 'ping with user agent' do
     @http.user_agent = "KDDI-CA32"
     assert_true(@http.ping)
+    assert_equal("KDDI-CA32", FakeWeb.last_request["user-agent"])
   end
 
   test 'redirect_limit accessor is defined' do


### PR DESCRIPTION
Ping::HTTP class has user_agent attribute but it was not used in the actual http requests.