### PR TITLE
Fix "No such file or directory - busybox"

### DIFF
--- a/lib/net/ping.rb
+++ b/lib/net/ping.rb
@@ -13,7 +13,7 @@ require_relative 'ping/http'
 RbConfig = Config unless Object.const_defined?(:RbConfig)
 
 begin
-  `busybox`
+  `busybox >/dev/null 2>&1`
   RbConfig::CONFIG['busybox'] = true
 rescue Errno::ENOENT
   RbConfig::CONFIG['busybox'] = false


### PR DESCRIPTION
When busybox wasn't available, an error message was displayed anytime this gem was included.

I added ">/dev/null 2>&1" to avoid it.