### PR TITLE
Add support for HTTP to ping urls requiring a query parameter

### DIFF
--- a/lib/net/ping/http.rb
+++ b/lib/net/ping/http.rb
@@ -149,7 +149,7 @@ module Net
       proxy = uri.find_proxy || URI.parse("")
 
       begin
-        uri_path = uri.path.empty? ? '/' : uri.path
+        uri_path = uri.path.empty? ? '/' : uri.request_uri
 
         headers = {}
         headers["User-Agent"] = user_agent if user_agent

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -12,6 +12,9 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
   def setup
     ENV['http_proxy'] = ENV['https_proxy'] = ENV['no_proxy'] = nil
     @uri = 'http://www.google.com/index.html'
+    @uri_without_query = 'https://play.google.com/store/apps/details'
+    @uri_with_query = 'https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox'
+
     @uri_https = 'https://encrypted.google.com'
     @uri_http_domain = 'http.com'
     @uri_http_domain_scheme = 'http://http.com'
@@ -21,6 +24,8 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
 
     FakeWeb.register_uri(:get, @uri, :body => "PONG")
     FakeWeb.register_uri(:head, @uri, :body => "PONG")
+    FakeWeb.register_uri(:get, @uri_with_query, :body => "PONG")
+    FakeWeb.register_uri(:head, @uri_with_query, :body => "PONG")
     FakeWeb.register_uri(:head, @uri_https, :body => "PONG")
     FakeWeb.register_uri(:get, @uri_https, :body => "PONG")
     FakeWeb.register_uri(:get, "http://#{@uri_http_domain}", :body => "PONG")
@@ -234,6 +239,15 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
   test 'ping with get option' do
     @http = Net::Ping::HTTP.new(@uri)
     @http.get_request = true
+    assert_true(@http.ping)
+  end
+
+  test 'ping_with_query' do
+    # without query doesnt work, but with query does
+    @http = Net::Ping::HTTP.new(@uri_without_query)
+    assert_false(@http.ping)
+
+    @http = Net::Ping::HTTP.new(@uri_with_query)
     assert_true(@http.ping)
   end
 


### PR DESCRIPTION
When pinging the google play store pages, it has the behavior that without a query parameter it fails ( https://play.google.com/store/apps/details vs https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox ).

 `Ping::HTTP` was only using the path instead of the full request part, so this switches to `request_uri`, which is what `Net::HTTP` uses.
