### PR TITLE
fix ruby 2.7.0 deprecation warning: deprecated Object#=~ 

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -66,7 +66,7 @@ module Net
                 bool = true  # Success, at least one response.
               end
 
-              if err & err =~ /warning/i
+              if err & (err =~ /warning/i)
                 @warning = err.chomp
               end
             when 2


### PR DESCRIPTION
I fixed the following deprecation warning which I got when using ruby 2.7.0

`warning: deprecated Object#=~ is called on FalseClass; it always returns nil`

The fix should be backwards compatible.