### PR TITLE
Fix gem metadata on rubygems

### DIFF
--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |spec|
   spec.summary   = 'A ping interface for Ruby.'
   spec.test_file = 'test/test_net_ping.rb'
   spec.files     = Dir['**/*'].reject{ |f| f.include?('git') }
+  spec.metadata = {
+    'bug_tracker_uri' => "#{spec.homepage}/issues",
+    'changelog_uri' => "#{spec.homepage}/blob/master/CHANGES",
+    'documentation_uri' => "https://www.rubydoc.info/gems/#{spec.name}",
+    'homepage_uri' => spec.homepage,
+    'source_code_uri' => spec.homepage
+  }
 
   spec.extra_rdoc_files  = ['README.md', 'CHANGES', 'doc/ping.txt']
 


### PR DESCRIPTION
In currect state `homepage` link on [rubygems](https://rubygems.org/gems/net-ping/) link to github of this project 
But source code link to old (and seems deprecated) bitbucket repo: https://bitbucket.org/chernesk/net-ping/src/master/

This raised question for me, since dependabot use source code link to fetch changes
I created issue at https://bitbucket.org/chernesk/net-ping/issues/2/source-code-of-gem-releases
but this PR should resolve everything