### PR TITLE
Create a universal-mingw32 gem for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # net-ping
+
 A collection of classes that provide different ways to ping computers.
 
 ## Prerequisites
   * ffi
   * win32-security (MS Windows only)
+  * cap2 (MS Windows only)
   * fakeweb (test only)
   * test-unit (test only)
 

--- a/net-ping-universal-mingw32.gemspec
+++ b/net-ping-universal-mingw32.gemspec
@@ -1,0 +1,8 @@
+gemspec = eval(IO.read(File.expand_path("chef.gemspec", __dir__)))
+
+gemspec.platform = Gem::Platform.new(%w{universal mingw32})
+
+gemspec.add_dependency('win32-security', '>= 0.2.0')
+gemspec.add_dependency('cap2', '>= 0.2.2')
+
+gemspec

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -1,6 +1,3 @@
-require 'rubygems'
-require 'rbconfig'
-
 Gem::Specification.new do |spec|
   spec.name      = 'net-ping'
   spec.version   = '2.0.8'
@@ -28,17 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('fakeweb', '>= 0')
   spec.add_development_dependency('rake', '>= 0')
   spec.add_development_dependency('pry-byebug', '>= 0')
-
-  if File::ALT_SEPARATOR
-    require 'rbconfig'
-    arch = RbConfig::CONFIG['build_os'] || 'mingw32' # JRuby
-    spec.platform = Gem::Platform.new(['universal', arch])
-    spec.platform.version = nil
-
-    # Used for icmp pings.
-    spec.add_dependency('win32-security', '>= 0.2.0')
-    spec.add_dependency('cap2', '>= 0.2.2')
-  end
 
   spec.description = <<-EOF
     The net-ping library provides a ping interface for Ruby. It includes


### PR DESCRIPTION
There needs to be a platform specific gemspec that is always used on
Windows not a main gemspec with conditional logic to add windows gems
based on the platform where the gem is uploaded to Rubygems.

Signed-off-by: Tim Smith <tsmith@chef.io>