### PR TITLE
Fix timeout option for `Ping::External#ping6` on macOS

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -116,8 +116,10 @@ module Net
           pcmd += ['-i', interval.to_s] unless RbConfig::CONFIG['busybox']
         when /aix/i
           pcmd += ['-c', count.to_s, '-w', timeout.to_s, host]
-        when /bsd|osx|mach|darwin/i
+        when /bsd|mach/i
           pcmd += ['-c', count.to_s, '-t', timeout.to_s, host]
+        when /osx|darwin/i
+          pcmd += ['-c', count.to_s, '-i', timeout.to_s, host]
         when /solaris|sunos/i
           pcmd += [host, timeout.to_s]
         when /hpux/i


### PR DESCRIPTION
This Pull Request fixes an issue on macOS where `Net::Ping::External#ping6` returns `false` even for reachable targets.

### Steps to reproduce
- macOS: 15.3
- ruby: 3.4.1
- net-ping: 2.0.8

```ruby
require 'net/ping'

pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> false

pe.exception
=> "ping6: nodename nor servname provided, or not known"
```

The `ping6` command to the same target(`2001:4860:4860::8888`) succeeds.
```sh
$ ping6 -c 1 2001:4860:4860::8888
PING6(56=40+8+8 bytes) 2001:268:c281:1ade:c461:6f59:7200:5235 --> 2001:4860:4860::8888
16 bytes from 2001:4860:4860::8888, icmp_seq=0 hlim=113 time=38.147 ms

--- 2001:4860:4860::8888 ping6 statistics ---
1 packets transmitted, 1 packets received, 0.0% packet loss
round-trip min/avg/max/std-dev = 38.147/38.147/38.147/0.000 ms
```

### Expected behavior
Ensure that `Net::Ping::External#ping6` succeeds and returns `true` on macOS.

```ruby
pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> true
```

### Actual behavior
`Net::Ping::External#ping6` return false even for reachable targets.

```ruby
pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> false

pe.exception
=> "ping6: nodename nor servname provided, or not known"
```

On macOS, `Net::Ping::External#ping6` executes the following command (with `-t` option), and the same error is returned.

```sh
$ ping6 -c 1 -t 5 2001:4860:4860::8888
ping6: nodename nor servname provided, or not known
```

### Details
It fixes the timeout option for `Net::Ping::External#ping6` on macOS.
macOS's `ping6` does not have the `-t` option to specify a timeout, so the `-i` option is used instead.

```sh
$ man ping6
...
     -i wait
             Wait wait seconds between sending each packet.  The default is to
             wait for one second between each packet.  The wait time may be
             fractional, but only the super-user may specify values less than
             0.002 second.  This option is incompatible with the -f option.
```

For reference, I have included the contents of the `ping6` man page from macOS 15.3 here:
https://gist.github.com/taketo1113/4cdae90f7344b121ce051562def4ba21
