### PR TITLE
Fix Net::Ping::VERSION

### DIFF
--- a/lib/net/ping/ping.rb
+++ b/lib/net/ping/ping.rb
@@ -1,6 +1,8 @@
 require 'socket'
 require 'timeout'
 
+require_relative 'version'
+
 # The Net module serves as a namespace only.
 #
 module Net
@@ -9,9 +11,6 @@ module Net
    # types. You should not instantiate this class directly.
    #
    class Ping
-      # The version of the net-ping library.
-      VERSION = '2.0.9'
-
       # The host to ping. In the case of Ping::HTTP, this is the URI.
       attr_accessor :host
 

--- a/lib/net/ping/version.rb
+++ b/lib/net/ping/version.rb
@@ -1,0 +1,6 @@
+module Net
+  class Ping
+    # The version of the net-ping library.
+    VERSION = '2.0.9'
+  end
+end

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -1,6 +1,8 @@
+require_relative "lib/net/ping/version"
+
 Gem::Specification.new do |spec|
   spec.name      = 'net-ping'
-  spec.version   = '2.0.9'
+  spec.version   = Net::Ping::VERSION
   spec.license   = 'Artistic 2.0'
   spec.author    = 'Chris Chernesky'
   spec.email     = 'chris.netping@tinderglow.com'

--- a/test/test_net_ping.rb
+++ b/test/test_net_ping.rb
@@ -39,6 +39,6 @@ end
 
 class TC_Net_Ping < Test::Unit::TestCase
   def test_net_ping_version
-    assert_equal('2.0.9', Net::Ping::VERSION)
+    assert_equal(Gem::Specification.load('net-ping.gemspec').version.to_s, Net::Ping::VERSION)
   end
 end


### PR DESCRIPTION
This Pull Request fixes `Net::Ping::VERSION`.

The version in the `net-ping` gem's gemspec is 2.0.8, but `Net::Ping::VERSION` is set to 1.7.6.
To resolve this inconsistency, `Net::Ping::VERSION` has been moved to a separate file, and the gemspec now references `Net::Ping::VERSION` from that file.

### Steps to reproduce
- ruby: 3.4.1
- net-ping: 2.0.8
```ruby
require 'net/ping'
Net::Ping::VERSION
```

### Expected behavior

```ruby
Net::Ping::VERSION
=> 2.0.8
```

### Actual behavior

```ruby
Net::Ping::VERSION
=> 1.7.6
```
