### PR TITLE
Update CI Matrix to Include Ruby 3.4 and Replace FakeWeb with WebMock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        ruby: ['3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get -y install libcap2 libcap-dev
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of classes that provide different ways to ping computers.
 ## Prerequisites
   * ffi
   * win32-security (MS Windows only)
-  * fakeweb (test only)
+  * webmock (test only)
   * test-unit (test only)
 
   Ruby users should use Ruby 1.9.3 or later.

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'rbconfig'
 
 Gem::Specification.new do |spec|
@@ -25,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_development_dependency('test-unit', '>= 0')
-  spec.add_development_dependency('fakeweb', '>= 0')
+  spec.add_development_dependency('webmock', '>= 0')
   spec.add_development_dependency('rake', '>= 0')
   spec.add_development_dependency('pry-byebug', '>= 0')
 

--- a/test/test_net_ping.rb
+++ b/test/test_net_ping.rb
@@ -8,7 +8,6 @@ require 'test_net_ping_external'
 require 'test_net_ping_http'
 require 'test_net_ping_tcp'
 require 'test_net_ping_udp'
-require 'fakeweb'
 
 if File::ALT_SEPARATOR
   require 'win32/security'
@@ -42,5 +41,3 @@ class TC_Net_Ping < Test::Unit::TestCase
     assert_equal('1.7.6', Net::Ping::VERSION)
   end
 end
-
-FakeWeb.allow_net_connect = false

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -5,49 +5,8 @@
 # 'test:http' Rake task.
 #################################################################################
 require 'test-unit'
-require 'fakeweb'
+require 'webmock/test_unit'
 require 'net/ping/http'
-
-# https://github.com/chrisk/fakeweb/commit/eed5056d19af2fe56d3f362ed32095bd8fb3fff7
-module FakeWeb
-  class StubSocket
-    def closed?
-      @closed ||= false
-      @closed
-    end
-
-    def close
-      @closed = true
-    end
-  end
-end
-
-# https://github.com/chrisk/fakeweb/commit/5bd70b72962081e46c7b22a39d00b7660d0ad30e
-module Net
-  class BufferedIO
-    def initialize_with_fakeweb(io, read_timeout: 60, write_timeout: 60, continue_timeout: nil, debug_output: nil)
-      @read_timeout = read_timeout
-      @write_timeout = write_timeout
-      @continue_timeout = continue_timeout
-      @debug_output = debug_output
-      @rbuf = ''.b
-
-      @io = case io
-      when Socket, OpenSSL::SSL::SSLSocket, IO
-        io
-      when String
-        if !io.include?("\0") && File.exists?(io) && !File.directory?(io)
-          File.open(io, "r")
-        else
-          StringIO.new(io)
-        end
-      end
-      raise "Unable to create local socket" unless @io
-    end
-    alias_method :initialize_without_fakeweb, :initialize
-    alias_method :initialize, :initialize_with_fakeweb
-  end
-end
 
 class TC_Net_Ping_HTTP < Test::Unit::TestCase
   def setup
@@ -58,27 +17,24 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     @uri_http_domain_scheme = 'http://http.com'
     @uri_http_domain_schemes = 'https://http.com'
     @proxy = 'http://username:password@proxymoxie:3128'
-    FakeWeb.allow_net_connect = false
+    WebMock.disable_net_connect!
 
-    FakeWeb.register_uri(:get, @uri, :body => "PONG")
-    FakeWeb.register_uri(:head, @uri, :body => "PONG")
-    FakeWeb.register_uri(:head, @uri_https, :body => "PONG")
-    FakeWeb.register_uri(:get, @uri_https, :body => "PONG")
-    FakeWeb.register_uri(:get, "http://#{@uri_http_domain}", :body => "PONG")
-    FakeWeb.register_uri(:head, "http://#{@uri_http_domain}", :body => "PONG")
-    FakeWeb.register_uri(:get, @uri_http_domain_scheme, :body => "PONG")
-    FakeWeb.register_uri(:head, @uri_http_domain_scheme, :body => "PONG")
-    FakeWeb.register_uri(:get, @uri_http_domain_schemes, :body => "PONG")
-    FakeWeb.register_uri(:head, @uri_http_domain_schemes, :body => "PONG")
-    FakeWeb.register_uri(:head, "https://jigsaw.w3.org/HTTP/300/302.html",
-                         :body => "PONG",
-                         :location => "#{@uri}",
-                         :status => ["302", "Found"])
+    stub_request(:get, @uri).to_return(body: "PONG")
+    stub_request(:head, @uri).to_return(body: "PONG")
+    stub_request(:head, @uri_https).to_return(body: "PONG")
+    stub_request(:get, @uri_https).to_return(body: "PONG")
+    stub_request(:get, "http://#{@uri_http_domain}").to_return(body: "PONG")
+    stub_request(:head, "http://#{@uri_http_domain}").to_return(body: "PONG")
+    stub_request(:get, @uri_http_domain_scheme).to_return(body: "PONG")
+    stub_request(:head, @uri_http_domain_scheme).to_return(body: "PONG")
+    stub_request(:get, @uri_http_domain_schemes).to_return(body: "PONG")
+    stub_request(:head, @uri_http_domain_schemes).to_return(body: "PONG")
 
-    FakeWeb.register_uri(:any, 'http://www.blabfoobarurghxxxx.com', :exception => SocketError)
-    FakeWeb.register_uri(:head, 'http://http502.com',
-                         :body => "",
-                         :status => ["502", "Bad Gateway"])
+    stub_request(:head, "https://jigsaw.w3.org/HTTP/300/302.html")
+      .to_return(body: "PONG", status: ["302", "Found"], headers: { 'location' => "#{@uri}" })
+
+    stub_request(:any, "http://www.blabfoobarurghxxxx.com").to_raise(SocketError)
+    stub_request(:head, "http://http502.com").to_return(body: "", status: ["502", "Bad Gateway"])
 
     @http = Net::Ping::HTTP.new(@uri, 80, 30)
     @http_http_domain = Net::Ping::HTTP.new(@uri_http_domain, 80, 30)
@@ -175,12 +131,12 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     assert_equal(5, @bad.timeout)
   end
 
-  # TODO: Figure out how to do this with FakeWeb.
+  # TODO: Figure out how to do this with WebMock.
   test 'ping fails if timeout exceeded' do
-    FakeWeb.allow_net_connect = true
+    WebMock.allow_net_connect!
     @http = Net::Ping::HTTP.new('https://www.google.com', 443, 0.001)
     assert_false(@http.ping?)
-    assert(['execution expired', 'Net::OpenTimeout'].include?(@http.exception))
+    assert(['Failed to open TCP connection to www.google.com:443 (execution expired)', 'execution expired', 'Net::OpenTimeout'].include?(@http.exception))
   end
 
   test 'exception attribute basic functionality' do
@@ -220,7 +176,7 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
   test 'ping with user agent' do
     @http.user_agent = "KDDI-CA32"
     assert_true(@http.ping)
-    assert_equal("KDDI-CA32", FakeWeb.last_request["user-agent"])
+    assert_requested(:any, @uri, headers: { "User-Agent" => "KDDI-CA32" }, times: 1)
   end
 
   test 'redirect_limit accessor is defined' do


### PR DESCRIPTION
This Pull Request introduces the following improvements:

- Update the CI matrix to add Ruby versions 3.0 - 3.4
- Replace fakeweb with webmock for Ruby 3.2 compatibility
- Fix circular require warning on Ruby 3.2 and later
- Fix test for ping http timeout on Ruby 3.1 and later

### Details
#### CI Matrix Update
Adds support for Ruby 3.4, 3.3, 3.2, 3.1, 3.0, and retains 2.7 in the GitHub Actions test matrix.

#### Replacing FakeWeb with WebMock
The `fakeweb` gem is no longer maintained and is not compatible with Ruby 3.2 or later.
`webmock` is an actively maintained and feature-rich alternative for HTTP request stubbing.
https://github.com/bblimke/webmock

This update:
- Modifies `README.md` and `net-ping.gemspec` to reflect the dependency change
- Refactors test cases to use WebMock syntax while ensuring backward compatibility

#### Fix circular require warning
The warning was occurring on Ruby 3.2 and later due to a circular require issue.
This was resolved by removing an unnecessary require statement from `net-ping.gemspec`.

```
/Users/taketo/.rbenv/versions/3.2.4/bin/ruby -w -I"lib" /path/net-ping/tmp/ruby/3.2.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/test_net_ping_external.rb" 
<internal:/Users/taketo/.rbenv/versions/3.2.4/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86: warning: <internal:/Users/taketo/.rbenv/versions/3.2.4/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86: warning: loading in progress, circular require considered harmful - /Users/taketo/.rbenv/versions/3.2.4/lib/ruby/3.2.0/rubygems.rb
	from <internal:gem_prelude>:2:in  `<internal:gem_prelude>'
```
