### PR TITLE
Fix exception attribute outputs `undefined method '=~' for false` when `Net::Ping::External#ping6` succeeds

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -66,7 +66,7 @@ module Net
                 bool = true  # Success, at least one response.
               end
 
-              if err & (err =~ /warning/i)
+              if err && (err =~ /warning/i)
                 @warning = err.chomp
               end
             when 2
@@ -149,7 +149,7 @@ module Net
                 bool = true  # Success, at least one response.
               end
 
-              if err & err =~ /warning/i
+              if err && (err =~ /warning/i)
                 @warning = err.chomp
               end
             when 2

--- a/test/test_net_ping_external.rb
+++ b/test/test_net_ping_external.rb
@@ -188,6 +188,41 @@ class TC_Net_Ping_External < Test::Unit::TestCase
     Open3.define_singleton_method(:popen3, original_popen3)
   end
 
+  test "ping6 succeeds without an exception when stderr is empty" do
+    stdin = StringIO.new
+    stdout = StringIO.new('64 bytes from ::1')
+    stderr = StringIO.new
+    status = Struct.new(:exitstatus).new(0)
+    thread = Struct.new(:value).new(status)
+    popen3 = Open3.method(:popen3)
+    nil_match = NilClass.instance_method(:=~) if NilClass.instance_methods(false).include?(:=~)
+    false_match = FalseClass.instance_method(:=~) if FalseClass.instance_methods(false).include?(:=~)
+
+    Open3.singleton_class.send(:define_method, :popen3) do |*args, &block|
+      block.call(stdin, stdout, stderr, thread)
+    end
+    [NilClass, FalseClass].each do |klass|
+      klass.send(:define_method, :=~) do |*args|
+        raise NoMethodError, "undefined method '=~' for #{self.inspect}"
+      end
+    end
+
+    assert_true(@pe.ping6('::1'))
+    assert_nil(@pe.exception)
+  ensure
+    Open3.singleton_class.send(:define_method, :popen3, popen3) if popen3
+    if nil_match
+      NilClass.send(:define_method, :=~, nil_match)
+    else
+      NilClass.send(:remove_method, :=~)
+    end
+    if false_match
+      FalseClass.send(:define_method, :=~, false_match)
+    else
+      FalseClass.send(:remove_method, :=~)
+    end
+  end
+
   def teardown
     @host  = nil
     @bogus = nil


### PR DESCRIPTION
This Pull Request fixes an issue where an `undefined method '=~' for false` error is output to the exception attribute when `Net::Ping::External#ping6` succeeds.

### Steps to reproduce
- ruby: 3.4.1
- net-ping: 2.0.8
- OS: CentOS Stream 9
```ruby
require 'net/ping'

pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> true

pe.exception
=> "undefined method '=~' for false"
```

### Expected behavior
When `Net::Ping::External#ping6` succeeds, the `exception` attribute should be `nil`, similar to how it behaves with `Net::Ping::External#ping`.

```ruby
# ping6
pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> true

pe.exception
=> nil


# ping
pe4 = Net::Ping::External.new("8.8.8.8") # dns.google
pe4.ping
=> true

pe4.exception
=> nil
```

### Actual behavior
When `Net::Ping::External#ping6` succeeds, the `exception` attribute is not `nil` and instead has the value `undefined method '=~' for false`.

```ruby
# ping6
pe = Net::Ping::External.new("2001:4860:4860::8888") # dns.google
pe.ping6
=> true

pe.exception
=> "undefined method '=~' for false"


# ping
pe4 = Net::Ping::External.new("8.8.8.8") # dns.google
pe4.ping
=> true

pe4.exception
=> nil
```

