### PR TITLE
Test against Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: ['3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
     steps:
       - uses: actions/checkout@v4
       - if: runner.os == 'Linux'

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -36,6 +36,9 @@ Gem::Specification.new do |spec|
 
     # Used for icmp pings.
     spec.add_dependency('win32-security', '>= 0.2.0')
+
+    # No longer a default gem as of Ruby 4.0. Used by the WMI ping class.
+    spec.add_dependency('win32ole', '>= 1.8.8')
   end
   spec.add_dependency('cap2', '>= 0.2.2') if RUBY_PLATFORM =~ /linux/i
 

--- a/test/test_net_ping_http.rb
+++ b/test/test_net_ping_http.rb
@@ -131,12 +131,11 @@ class TC_Net_Ping_HTTP < Test::Unit::TestCase
     assert_equal(5, @bad.timeout)
   end
 
-  # TODO: Figure out how to do this with WebMock.
   test 'ping fails if timeout exceeded' do
-    WebMock.allow_net_connect!
+    stub_request(:head, 'https://www.google.com/').to_timeout
     @http = Net::Ping::HTTP.new('https://www.google.com', 443, 0.001)
     assert_false(@http.ping?)
-    assert(['Failed to open TCP connection to www.google.com:443 (execution expired)', 'execution expired', 'Net::OpenTimeout'].include?(@http.exception))
+    assert_include(['execution expired', 'Net::OpenTimeout'], @http.exception)
   end
 
   test 'exception attribute basic functionality' do


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to the GitHub Actions test matrix.
- Add `win32ole` as an explicit Windows-only gem dependency, since it is no longer a default gem as of Ruby 4.0 (fixes the `windows-latest, 4.0` CI failure).
- Update the HTTP ping timeout test to use WebMock's `to_timeout` instead of allowing real outbound network connections, and assert against a small set of acceptable timeout exception messages instead of an exact match.

## Testing
- YAML matrix validation
- `bundle exec rake test` (macOS, Ruby 3.3): 96 runs, 0 failures
- CI: all matrix jobs (ubuntu-latest / windows-latest × Ruby 2.7-4.0) pass