### PR TITLE
Release 2.0.9

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,1 +1,12 @@
-Updated changes coming soon..
+== 2.0.9 - 25-Jul-2026
+* Add GitHub Actions CI [#33](https://github.com/eitoball/net-ping/pull/33)
+  and update its supported Ruby versions [#38](https://github.com/eitoball/net-ping/pull/38).
+* Replace FakeWeb with WebMock and update the test suite for current Ruby
+  versions [#38](https://github.com/eitoball/net-ping/pull/38).
+* Skip external-ping tests when the system ping command is unavailable
+  [#33](https://github.com/eitoball/net-ping/pull/33).
+* Fix the macOS ping6 interval option
+  [#40](https://github.com/eitoball/net-ping/pull/40).
+* Update README wording [#30](https://github.com/eitoball/net-ping/pull/30).
+* Align Net::Ping::VERSION with the gem version
+  [#37](https://github.com/eitoball/net-ping/pull/37).

--- a/lib/net/ping/ping.rb
+++ b/lib/net/ping/ping.rb
@@ -10,7 +10,7 @@ module Net
    #
    class Ping
       # The version of the net-ping library.
-      VERSION = '1.7.6'
+      VERSION = '2.0.9'
 
       # The host to ping. In the case of Ping::HTTP, this is the URI.
       attr_accessor :host

--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -2,7 +2,7 @@ require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name      = 'net-ping'
-  spec.version   = '2.0.8'
+  spec.version   = '2.0.9'
   spec.license   = 'Artistic 2.0'
   spec.author    = 'Chris Chernesky'
   spec.email     = 'chris.netping@tinderglow.com'

--- a/test/test_net_ping.rb
+++ b/test/test_net_ping.rb
@@ -38,6 +38,6 @@ end
 
 class TC_Net_Ping < Test::Unit::TestCase
   def test_net_ping_version
-    assert_equal('1.7.6', Net::Ping::VERSION)
+    assert_equal('2.0.9', Net::Ping::VERSION)
   end
 end


### PR DESCRIPTION
## Summary
- release net-ping 2.0.9
- synchronize the gemspec, Net::Ping::VERSION, and its test
- document CI, test compatibility, external ping, and macOS ping6 updates

## Validation
- `ruby -Ilib:test test/test_net_ping.rb`
- `gem build net-ping.gemspec`