### PR TITLE
Fix FreeBSD ping6 timeout option

### DIFF
--- a/lib/net/ping/external.rb
+++ b/lib/net/ping/external.rb
@@ -116,6 +116,8 @@ module Net
           pcmd += ['-i', interval.to_s] unless RbConfig::CONFIG['busybox']
         when /aix/i
           pcmd += ['-c', count.to_s, '-w', timeout.to_s, host]
+        when /freebsd/i
+          pcmd += ['-c', count.to_s, '-x', timeout.to_s, host]
         when /bsd|osx|mach|darwin/i
           pcmd += ['-c', count.to_s, '-i', interval.to_s, host]
         when /solaris|sunos/i

--- a/test/test_net_ping_external.rb
+++ b/test/test_net_ping_external.rb
@@ -140,6 +140,30 @@ class TC_Net_Ping_External < Test::Unit::TestCase
     assert_false(@bad.ping?)
   end
 
+  test "ping6 uses timeout for FreeBSD" do
+    command = nil
+    original_os = RbConfig::CONFIG['host_os']
+    original_popen3 = Open3.method(:popen3)
+
+    RbConfig::CONFIG['host_os'] = 'freebsd'
+    Open3.define_singleton_method(:popen3) do |*args, &block|
+      command = args
+      stdin = StringIO.new
+      stdout = StringIO.new
+      stderr = StringIO.new
+      status = Struct.new(:exitstatus).new(0)
+      thread = Struct.new(:value).new(status)
+      block.call(stdin, stdout, stderr, thread)
+    end
+
+    @pe.ping6('example.test', 2, 3, 4)
+
+    assert_equal(['ping6', '-c', '2', '-x', '4', 'example.test'], command)
+  ensure
+    RbConfig::CONFIG['host_os'] = original_os
+    Open3.define_singleton_method(:popen3, original_popen3)
+  end
+
   test "ping6 uses interval for macOS" do
     command = nil
     original_os = RbConfig::CONFIG['host_os']


### PR DESCRIPTION
## Summary
- use `ping6 -x` for FreeBSD timeouts
- add a regression test for the FreeBSD command arguments

Closes #28

<details>
<summary>Spec</summary>

# FreeBSD ping6 timeout design

## Goal

Correct `Net::Ping::External#ping6` on FreeBSD so that its timeout argument
uses FreeBSD's `ping6 -x` option.

## Scope

Only the FreeBSD `ping6` command construction changes. The existing macOS and
other BSD behavior remains unchanged.

## Design

Add a `/freebsd/i` OS branch before the existing BSD/macOS branch in
`lib/net/ping/external.rb`. It constructs this command:

```ruby
['ping6', '-c', count.to_s, '-x', timeout.to_s, host]
```

The FreeBSD command does not receive `-i` or the `interval` value. Existing
argument validation remains in place.

## Testing

Add an external-ping unit test that temporarily identifies the platform as
FreeBSD and intercepts `Open3.popen3`. It calls `ping6` with distinct count,
interval, and timeout values, and asserts the entire argument list. This
proves that the timeout uses `-x` and the interval is not passed.

The test performs no real network I/O and does not require FreeBSD.

## Compatibility

`ping`, the macOS `ping6` interval behavior, all other platform branches, and
the existing result and error handling are unchanged.
</details>

<details>
<summary>Plan</summary>

# FreeBSD ping6 Timeout Implementation Plan

> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

**Goal:** Make `Net::Ping::External#ping6` pass its timeout to FreeBSD's `ping6` with `-x`.

**Architecture:** Add a narrow FreeBSD OS branch before the existing BSD/macOS branch in the command builder. Cover the branch with a mocked `Open3.popen3` test that asserts the complete command array without requiring a FreeBSD host or network access.

**Tech Stack:** Ruby, Test::Unit, Open3, Rake.

## Global Constraints

- Change only the FreeBSD `ping6` command construction; preserve macOS and every other platform branch.
- FreeBSD must construct `['ping6', '-c', count.to_s, '-x', timeout.to_s, host]`.
- Do not pass `-i` or `interval` to FreeBSD `ping6`; keep existing argument validation unchanged.
- Tests must not run a real ping or require FreeBSD.

---

## File Structure

| File | Responsibility |
| --- | --- |
| `lib/net/ping/external.rb` | Select FreeBSD's `ping6` timeout option while preserving existing platform-specific command assembly. |
| `test/test_net_ping_external.rb` | Assert the FreeBSD `ping6` command array using the existing `Open3.popen3` interception pattern. |

### Task 1: Add FreeBSD ping6 timeout handling

**Files:**
- Modify: `lib/net/ping/external.rb:113-129`
- Modify: `test/test_net_ping_external.rb:143-165`
- Test: `test/test_net_ping_external.rb`

**Interfaces:**
- Consumes: `Net::Ping::External#ping6(host = @host, count = 1, interval = 1, timeout = @timeout)`.
- Produces: For `RbConfig::CONFIG['host_os'] == 'freebsd'`, `Open3.popen3` receives `['ping6', '-c', count.to_s, '-x', timeout.to_s, host]`.

- [ ] **Step 1: Write the failing FreeBSD command test**

Add this test immediately before the existing macOS `ping6` test:

```ruby
  test "ping6 uses timeout for FreeBSD" do
    command = nil
    original_os = RbConfig::CONFIG['host_os']
    original_popen3 = Open3.method(:popen3)

    RbConfig::CONFIG['host_os'] = 'freebsd'
    Open3.define_singleton_method(:popen3) do |*args, &block|
      command = args
      stdin = StringIO.new
      stdout = StringIO.new
      stderr = StringIO.new
      status = Struct.new(:exitstatus).new(0)
      thread = Struct.new(:value).new(status)
      block.call(stdin, stdout, stderr, thread)
    end

    @pe.ping6('example.test', 2, 3, 4)

    assert_equal(['ping6', '-c', '2', '-x', '4', 'example.test'], command)
  ensure
    RbConfig::CONFIG['host_os'] = original_os
    Open3.define_singleton_method(:popen3, original_popen3)
  end
```

- [ ] **Step 2: Run the targeted test to verify it fails**

Run:

```sh
bundle exec rake test:external
```

Expected: FAIL because the current BSD/macOS branch passes
`['ping6', '-c', '2', '-i', '3', 'example.test']`.

- [ ] **Step 3: Add the minimal FreeBSD command branch**

In `Net::Ping::External#ping6`, place this branch before
`when /bsd|osx|mach|darwin/i`:

```ruby
        when /freebsd/i
          pcmd += ['-c', count.to_s, '-x', timeout.to_s, host]
```

Do not alter the following macOS/BSD branch:

```ruby
        when /bsd|osx|mach|darwin/i
          pcmd += ['-c', count.to_s, '-i', interval.to_s, host]
```

- [ ] **Step 4: Run the targeted external-ping suite**

Run:

```sh
bundle exec rake test:external
```

Expected: PASS, including both the new FreeBSD test and the existing macOS
interval test.

- [ ] **Step 5: Run the full regression suite**

Run:

```sh
bundle exec rake test
```

Expected: PASS with no failures or errors.

- [ ] **Step 6: Commit the implementation**

```sh
git add lib/net/ping/external.rb test/test_net_ping_external.rb
git commit -m "Fix FreeBSD ping6 timeout option"
```
</details>