### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,18 @@
-== Next Release
+== 2.1.0 - 08-Aug-2026
 * Publish platform-specific gem metadata so Linux installs cap2 and current
-  Windows RubyInstaller installs win32-security for ICMP support.
+  Windows RubyInstaller installs win32-security for ICMP support
+  [#44](https://github.com/eitoball/net-ping/pull/44).
+* Fix the FreeBSD ping6 timeout option
+  [#43](https://github.com/eitoball/net-ping/pull/43).
+* Add Ruby 4.0 to the test matrix and add win32ole as an explicit Windows
+  dependency, since it is no longer a default gem as of Ruby 4.0
+  [#41](https://github.com/eitoball/net-ping/pull/41).
+* Move Net::Ping::VERSION into its own file so the gemspec version can no
+  longer drift out of sync with it
+  [#37](https://github.com/eitoball/net-ping/pull/37).
+* Fix `Net::Ping::External#ping6` setting a spurious "undefined method '=~'
+  for false" exception on success
+  [#39](https://github.com/eitoball/net-ping/pull/39).
 
 == 2.0.9 - 25-Jul-2026
 * Add GitHub Actions CI [#33](https://github.com/eitoball/net-ping/pull/33)

--- a/lib/net/ping/version.rb
+++ b/lib/net/ping/version.rb
@@ -1,6 +1,6 @@
 module Net
   class Ping
     # The version of the net-ping library.
-    VERSION = '2.0.9'
+    VERSION = '2.1.0'
   end
 end


### PR DESCRIPTION
## Summary
- release net-ping 2.1.0
- synchronize the gemspec, Net::Ping::VERSION, and its test
- document platform-specific gem metadata (#44) and the FreeBSD ping6 timeout fix (#43)

## Validation
- `bundle exec rake test`
- `bundle exec rake gem:create gem:check`