### PR TITLE
Fix license format in net-ping.gemspec

### DIFF
--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -3,7 +3,7 @@ require_relative "lib/net/ping/version"
 Gem::Specification.new do |spec|
   spec.name      = 'net-ping'
   spec.version   = Net::Ping::VERSION
-  spec.license   = 'Artistic 2.0'
+  spec.license   = 'Artistic-2.0'
   spec.author    = 'Chris Chernesky'
   spec.email     = 'chris.netping@tinderglow.com'
   spec.homepage  = 'https://github.com/chernesk/net-ping'


### PR DESCRIPTION
By changing it to "Artistic-2.0", it becomes a valid [SPDX license identifier](https://spdx.org/licenses/Artistic-2.0.html), which helps tools.