### PR TITLE
Exclude CLAUDE.md and docs/ from packaged gem files

### DIFF
--- a/net-ping.gemspec
+++ b/net-ping.gemspec
@@ -9,7 +9,9 @@ Gem::Specification.new do |spec|
   spec.homepage  = 'https://github.com/chernesk/net-ping'
   spec.summary   = 'A ping interface for Ruby.'
   spec.test_file = 'test/test_net_ping.rb'
-  spec.files     = Dir['**/*'].reject { |f| f.include?('git') || File.extname(f) == '.gem' }
+  spec.files     = Dir['**/*'].reject do |f|
+    f.include?('git') || File.extname(f) == '.gem' || f == 'CLAUDE.md' || f == 'docs' || f.start_with?('docs/')
+  end
   spec.metadata = {
     'bug_tracker_uri' => "#{spec.homepage}/issues",
     'changelog_uri' => "#{spec.homepage}/blob/master/CHANGES",

--- a/test/test_net_ping_gem_packaging.rb
+++ b/test/test_net_ping_gem_packaging.rb
@@ -78,6 +78,16 @@ class TestNetPingGemPackaging < Test::Unit::TestCase
     delete_files(built_gem_files)
   end
 
+  def test_gem_create_excludes_non_distributable_project_files_from_spec_files
+    load_specifications.each do |path, spec|
+      non_distributable = spec.files.select do |f|
+        f == 'CLAUDE.md' || f == 'docs' || f.start_with?('docs/')
+      end
+
+      assert_equal([], non_distributable, path)
+    end
+  end
+
   def test_gem_check_uses_fixed_expectations_instead_of_loaded_specifications
     stdout, stderr, status = run_rake('clean', 'gem:create')
 


### PR DESCRIPTION
## Summary
- `spec.files` globbed every file on disk (`Dir['**/*']`), so AI-assistant instructions (`CLAUDE.md`) and session notes (`docs/superpowers/**`) ended up shipped inside the `net-ping-2.1.0` gem, breaking downstream RPM packaging.
- Explicitly excludes `CLAUDE.md` and everything under `docs/` from `spec.files`. The two platform gemspecs (`net-ping-universal-*.gemspec`) `dup` this spec, so they inherit the fix automatically.

Fixes #46

## Test plan
- [x] Added `test_gem_create_excludes_non_distributable_project_files_from_spec_files`, watched it fail against the old `spec.files` (listed `CLAUDE.md` and all `docs/superpowers/**` entries), then confirmed it passes after the fix.
- [x] `bundle exec rake test` — 110 tests, 0 failures.