### PR TITLE
Prepare 2.1.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+== 2.1.1 - 16-Aug-2026
+* Fix the license format in net-ping.gemspec to use the SPDX identifier
+  "Artistic-2.0" [#47](https://github.com/eitoball/net-ping/pull/47).
+* Exclude CLAUDE.md and docs/ from the packaged gem files
+  [#48](https://github.com/eitoball/net-ping/pull/48).
+
 == 2.1.0 - 08-Aug-2026
 * Publish platform-specific gem metadata so Linux installs cap2 and current
   Windows RubyInstaller installs win32-security for ICMP support

--- a/lib/net/ping/version.rb
+++ b/lib/net/ping/version.rb
@@ -1,6 +1,6 @@
 module Net
   class Ping
     # The version of the net-ping library.
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end


### PR DESCRIPTION
## Summary
- Bump `Net::Ping::VERSION` to 2.1.1
- Add a 2.1.1 CHANGES entry for the SPDX license fix in #47
- Add a 2.1.1 CHANGES entry for excluding CLAUDE.md/docs from the packaged gem in #48

## Test plan
- [x] `bundle exec rake test` (110 tests, 0 failures)